### PR TITLE
Add KoreanBots integration for server count updates

### DIFF
--- a/juhee-bot/.env.example
+++ b/juhee-bot/.env.example
@@ -6,6 +6,9 @@ CLIENT_ID=your_discord_client_id_here
 AZURE_KEY=your_azure_cognitive_services_key_here
 AZURE_REGION=your_azure_region_here
 
+# Korean Discord List (Optional)
+KOREANBOTS_TOKEN=your_koreanbots_token_here
+
 # Node Environment
 NODE_ENV=production
 

--- a/juhee-bot/app/shard.ts
+++ b/juhee-bot/app/shard.ts
@@ -15,6 +15,8 @@ import path from "path";
 
 /** Discord 봇 토큰 */
 const TOKEN: string = process.env.TOKEN ?? "";
+/** 한국 디스코드 리스트 API 토큰 (선택 사항) */
+const KOREANBOTS_TOKEN: string = process.env.KOREANBOTS_TOKEN ?? "";
 
 if (!TOKEN) {
   logger.error("❌ Discord 봇 토큰이 설정되지 않았습니다. .env 파일을 확인하세요.");
@@ -176,7 +178,7 @@ manager
   });
 
 /**
- * 샤드 통계 출력 (5분마다)
+ * 샤드 통계 출력 및 한국 디스코드 리스트 업데이트 (10분마다)
  */
 setInterval(async () => {
   try {
@@ -196,11 +198,39 @@ setInterval(async () => {
       logger.info(`   📍 샤드 #${index}: ${guildCount}개 서버`);
     });
 
+    // 한국 디스코드 리스트 업데이트
+    if (KOREANBOTS_TOKEN) {
+      try {
+        const response = await fetch("https://koreanbots.dev/api/v2/bots/servers", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Authorization": KOREANBOTS_TOKEN,
+          },
+          body: JSON.stringify({
+            servers: totalGuilds,
+            shards: manager.totalShards,
+          }),
+        });
+
+        if (response.ok) {
+          logger.info(`   ✅ 한국 디스코드 리스트 업데이트 성공`);
+        } else {
+          const errorText = await response.text();
+          logger.warn(`   ⚠️ 한국 디스코드 리스트 업데이트 실패: ${response.status} - ${errorText}`);
+        }
+      } catch (kbError) {
+        logger.warn(`   ⚠️ 한국 디스코드 리스트 업데이트 오류:`, kbError);
+      }
+    } else {
+      logger.debug(`   ℹ️ KOREANBOTS_TOKEN이 설정되지 않아 한국 디스코드 리스트 업데이트를 건너뜁니다.`);
+    }
+
     logger.info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
   } catch (error) {
     logger.error("❌ 샤드 통계 수집 오류:", error);
   }
-}, 300000); // 5분 (300초)
+}, 600000); // 10분 (600초)
 
 /**
  * 샤드 간 통신 예시

--- a/juhee-bot/package-lock.json
+++ b/juhee-bot/package-lock.json
@@ -15,6 +15,7 @@
         "@snazzah/davey": "^0.1.7",
         "discord.js": "^14.24.2",
         "dotenv": "^17.2.3",
+        "koreanbots": "^3.2.1",
         "libsodium-wrappers": "^0.7.15",
         "microsoft-cognitiveservices-speech-sdk": "^1.46.0",
         "node-audio-mixer": "^2.1.0",
@@ -343,6 +344,7 @@
       "integrity": "sha512-HHEnSNrSPmFEyndRdQBJN2YE6egyXS9JUnJWyP6jficK0Y+qKMEZXyYTgmzpjrxXP1exM/hKaNP7BRBUEWkU5w==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discordjs/node-pre-gyp": "^0.4.5",
         "node-addon-api": "^8.1.0"
@@ -1441,9 +1443,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1634,11 +1636,25 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1651,8 +1667,19 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -1843,16 +1870,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -2386,6 +2403,13 @@
         "node": ">= 12"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2519,6 +2543,31 @@
       "dev": true,
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/koreanbots": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koreanbots/-/koreanbots-3.2.1.tgz",
+      "integrity": "sha512-BmHNrhiUv/DO66K3fRtY0tmbVaqfi86bt8p7Sa+nde0jxxUjDYYGpOQ44G17r5+s0ZP6S7M8KzutNDKmG78liw==",
+      "license": "MIT",
+      "dependencies": {
+        "discord.js": ">=13",
+        "undici": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=16.6.0"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.29.1"
+      }
+    },
+    "node_modules/koreanbots/node_modules/undici": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.16.0.tgz",
+      "integrity": "sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.18"
+      }
     },
     "node_modules/libsodium": {
       "version": "0.7.15",
@@ -3889,6 +3938,50 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
     },
+    "node_modules/sharp": {
+      "version": "0.29.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.3.tgz",
+      "integrity": "sha512-fKWUuOw77E4nhpyzCCJR1ayrttHoFHBT2U/kR/qEMRhvPEcluG4BKj324+SCO1e84+knXHwhJ1HHJGnUt4ElGA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.0.1",
+        "detect-libc": "^1.0.3",
+        "node-addon-api": "^4.2.0",
+        "prebuild-install": "^7.0.0",
+        "semver": "^7.3.5",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.1.1",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/sharp/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/shimmer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
@@ -3945,6 +4038,16 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/simple-update-notifier": {
@@ -4199,9 +4302,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -4402,9 +4505,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.15",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
-      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "version": "13.15.20",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
+      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"

--- a/juhee-bot/package.json
+++ b/juhee-bot/package.json
@@ -44,6 +44,7 @@
     "@snazzah/davey": "^0.1.7",
     "discord.js": "^14.24.2",
     "dotenv": "^17.2.3",
+    "koreanbots": "^3.2.1",
     "libsodium-wrappers": "^0.7.15",
     "microsoft-cognitiveservices-speech-sdk": "^1.46.0",
     "node-audio-mixer": "^2.1.0",


### PR DESCRIPTION
Introduces support for updating the Korean Discord List (KoreanBots) with the current server and shard count every 10 minutes. Adds KOREANBOTS_TOKEN to the environment configuration, updates both non-sharded and sharded bot modes to send server statistics, and adds the 'koreanbots' package as a dependency.