### PR TITLE
Update Koreanbots API auth header to use Bearer token

### DIFF
--- a/juhee-bot/app/index.ts
+++ b/juhee-bot/app/index.ts
@@ -1274,11 +1274,10 @@ if (KOREANBOTS_TOKEN && !client.shard) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": KOREANBOTS_TOKEN,
+          "Authorization": `Bearer ${KOREANBOTS_TOKEN}`,
         },
         body: JSON.stringify({
           servers: totalGuilds,
-          shards: 1,
         }),
       });
 

--- a/juhee-bot/app/shard.ts
+++ b/juhee-bot/app/shard.ts
@@ -205,7 +205,7 @@ setInterval(async () => {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "Authorization": KOREANBOTS_TOKEN,
+            "Authorization": `Bearer ${KOREANBOTS_TOKEN}`,
           },
           body: JSON.stringify({
             servers: totalGuilds,


### PR DESCRIPTION
Changed the 'Authorization' header to use the 'Bearer' scheme when sending requests to the Koreanbots API. Also removed the unused 'shards' field from the request body in index.ts.