### PR TITLE
Update Koreanbots stats API integration

### DIFF
--- a/juhee-bot/.env.example
+++ b/juhee-bot/.env.example
@@ -7,7 +7,8 @@ AZURE_KEY=your_azure_cognitive_services_key_here
 AZURE_REGION=your_azure_region_here
 
 # Korean Discord List (Optional)
-KOREANBOTS_TOKEN=your_koreanbots_token_here
+# Koreanbots 봇 토큰 (https://koreanbots.dev/bots/{봇ID}/stats 에서 확인)
+KOREANBOTS_TOKEN=your_koreanbots_bot_token_here
 
 # Node Environment
 NODE_ENV=production

--- a/juhee-bot/app/index.ts
+++ b/juhee-bot/app/index.ts
@@ -1270,11 +1270,11 @@ if (KOREANBOTS_TOKEN && !client.shard) {
     try {
       const totalGuilds = client.guilds.cache.size;
 
-      const response = await fetch("https://koreanbots.dev/api/v2/bots/servers", {
+      const response = await fetch(`https://koreanbots.dev/api/v2/bots/${CLIENT_ID}/stats`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": `Bearer ${KOREANBOTS_TOKEN}`,
+          "Authorization": KOREANBOTS_TOKEN,
         },
         body: JSON.stringify({
           servers: totalGuilds,

--- a/juhee-bot/app/shard.ts
+++ b/juhee-bot/app/shard.ts
@@ -15,6 +15,8 @@ import path from "path";
 
 /** Discord 봇 토큰 */
 const TOKEN: string = process.env.TOKEN ?? "";
+/** Discord 애플리케이션 클라이언트 ID (봇 ID) */
+const CLIENT_ID: string = process.env.CLIENT_ID ?? "";
 /** 한국 디스코드 리스트 API 토큰 (선택 사항) */
 const KOREANBOTS_TOKEN: string = process.env.KOREANBOTS_TOKEN ?? "";
 
@@ -199,13 +201,13 @@ setInterval(async () => {
     });
 
     // 한국 디스코드 리스트 업데이트
-    if (KOREANBOTS_TOKEN) {
+    if (KOREANBOTS_TOKEN && CLIENT_ID) {
       try {
-        const response = await fetch("https://koreanbots.dev/api/v2/bots/servers", {
+        const response = await fetch(`https://koreanbots.dev/api/v2/bots/${CLIENT_ID}/stats`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "Authorization": `Bearer ${KOREANBOTS_TOKEN}`,
+            "Authorization": KOREANBOTS_TOKEN,
           },
           body: JSON.stringify({
             servers: totalGuilds,


### PR DESCRIPTION
Changed the Koreanbots stats API endpoint to include the bot's CLIENT_ID and updated the Authorization header to use the token directly. Also improved environment variable documentation and ensured CLIENT_ID is required for stats updates.